### PR TITLE
Re-order imports

### DIFF
--- a/simple-blog/src/app/app.component.spec.ts
+++ b/simple-blog/src/app/app.component.spec.ts
@@ -1,11 +1,11 @@
 import { TestBed } from '@angular/core/testing';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+
 import { AppComponent } from './app.component';
 import { BlogNavbarComponent } from './blog-navbar/blog-navbar.component';
+
 import { MatDialogModule } from '@angular/material/dialog'
-import { MatToolbarModule } from '@angular/material/toolbar';
-import { RouterTestingModule } from '@angular/router/testing';
-
-
+import { FormsModule } from '@angular/forms';
 
 describe('AppComponent', () => {
   let fixture = null;
@@ -17,10 +17,10 @@ describe('AppComponent', () => {
         BlogNavbarComponent,
       ],
       imports: [
-        MatDialogModule,
-        MatToolbarModule,
-        RouterTestingModule
+        FormsModule,
+        MatDialogModule
       ],
+      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
     }).compileComponents();
     fixture = TestBed.createComponent(AppComponent);
     app = fixture.componentInstance;

--- a/simple-blog/src/app/blog-dialogs/login-dialog/login-dialog.component.spec.ts
+++ b/simple-blog/src/app/blog-dialogs/login-dialog/login-dialog.component.spec.ts
@@ -1,10 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+
 import { AppComponent } from '../../app.component';
 import { BlogNavbarComponent } from '../../blog-navbar/blog-navbar.component';
-import { MatDialogModule } from '@angular/material/dialog'
-import { MatToolbarModule } from '@angular/material/toolbar';
-
 import { LoginDialogComponent } from './login-dialog.component';
 
 describe('LoginDialogComponent', () => {
@@ -13,17 +11,12 @@ describe('LoginDialogComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ 
+      declarations: [
         AppComponent,
         BlogNavbarComponent,
         LoginDialogComponent
       ],
-      imports: [
-        MatDialogModule,
-        MatToolbarModule,
-        RouterTestingModule
-        
-      ],
+      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
     })
     .compileComponents();
   });
@@ -42,6 +35,6 @@ describe('LoginDialogComponent', () => {
     fixture.detectChanges();
     const compiled = fixture.nativeElement;
     const loginButton = compiled.querySelector('#login-form-btn');
-    expect(loginButton).toBeTruthy;
+    expect(loginButton).toBeDefined();
   });
 });

--- a/simple-blog/src/app/blog-home-page/blog-home-page.component.spec.ts
+++ b/simple-blog/src/app/blog-home-page/blog-home-page.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 
 import { BlogHomePageComponent } from './blog-home-page.component';
 
@@ -8,7 +9,8 @@ describe('BlogHomePageComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ BlogHomePageComponent ]
+      declarations: [ BlogHomePageComponent ],
+      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
     })
     .compileComponents();
   });

--- a/simple-blog/src/app/blog-navbar/blog-navbar.component.spec.ts
+++ b/simple-blog/src/app/blog-navbar/blog-navbar.component.spec.ts
@@ -1,7 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatDialogModule } from '@angular/material/dialog'
-import { MatToolbarModule } from '@angular/material/toolbar';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 
+import { MatDialogModule } from '@angular/material/dialog'
+import { FormsModule } from '@angular/forms';
 
 import { BlogNavbarComponent } from './blog-navbar.component';
 
@@ -13,10 +14,11 @@ describe('BlogNavbarComponent', () => {
     await TestBed.configureTestingModule({
       declarations: [ BlogNavbarComponent ],
       imports: [
-        MatDialogModule,
-        MatToolbarModule
+        FormsModule,
+        MatDialogModule
       ],
-    })
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
+  })
     .compileComponents();
   });
 


### PR DESCRIPTION
# PR Description
import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
Then add schemas: [ CUSTOM_ELEMENTS_SCHEMA ] to TestBed in each test, so that we do not have to
constantly fight with adding imports in each test.
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Aditonal Context or Relevant Issues
Please include additional context.

## Issue Link
Please link the original issue URL.

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
